### PR TITLE
Fix multiple breaking when deleting first image in list

### DIFF
--- a/src/Filament/AttachmentInput.php
+++ b/src/Filament/AttachmentInput.php
@@ -75,7 +75,10 @@ class AttachmentInput extends Field
                 ->size('sm')
                 ->action(function (Set $set, array $arguments, $state) {
                     if ($this->isMultiple()) {
-                        $state = Arr::where($state, fn ($id) => $id !== $arguments['attachmentId']);
+                        $state = collect($state)
+                            ->reject(fn ($id) => $id === $arguments['attachmentId'])
+                            ->values();
+
                         $set($this->getStatePath(false), $state);
                     } else {
                         $set($this->getStatePath(false), null);

--- a/src/Filament/AttachmentInput.php
+++ b/src/Filament/AttachmentInput.php
@@ -79,7 +79,7 @@ class AttachmentInput extends Field
                             ->reject(fn ($id) => $id === $arguments['attachmentId'])
                             ->values();
 
-                        $set($this->getStatePath(false), $state);
+                        $set($this->getStatePath(false), $state->toArray());
                     } else {
                         $set($this->getStatePath(false), null);
                     }


### PR DESCRIPTION
Steps to reproduce:
- Have 2 images in a multiple input field
- Remove the first one
- Try to "select" new attachment -> boom