### PR TITLE
Fix formatter remembering previous format's crop when switching formats

### DIFF
--- a/resources/views/livewire/formatter-modal.blade.php
+++ b/resources/views/livewire/formatter-modal.blade.php
@@ -60,11 +60,7 @@
                 },
                 setFormat (key) {
                     this.currentFormat = this.formats[key] || null
-
-                    if (this.currentFormat) {
-                        window.cropper.setAspectRatio(this.currentFormat.aspectRatio)
-                        window.cropper.setData(this.previousFormats[this.currentFormat.key] || {})
-                    }
+                    this.loadFormatter()
                 }
             }"
             x-on:filament-media-library::load-formatter.window="loadFormatter()"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ use Filament\Tables\TablesServiceProvider;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use OwenVoke\BladeFontAwesome\BladeFontAwesomeServiceProvider;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Spatie\Image\Manipulations;
 use Spatie\Translatable\TranslatableServiceProvider;
@@ -44,6 +45,7 @@ class TestCase extends Orchestra
             FilamentServiceProvider::class,
             FormsServiceProvider::class,
             LivewireServiceProvider::class,
+            BladeFontAwesomeServiceProvider::class,
             NotificationsServiceProvider::class,
             SupportServiceProvider::class,
             TablesServiceProvider::class,

--- a/tests/Unit/Livewire/FormatterModalTest.php
+++ b/tests/Unit/Livewire/FormatterModalTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Codedor\MediaLibrary\Livewire\FormatterModal;
+use Codedor\MediaLibrary\Tests\TestFormats\TestHero;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->attachment = createAttachment([
+        'type' => 'image',
+        'extension' => 'jpg',
+    ]);
+});
+
+it('passes the stored crop data of an attachment to the formatter view', function () {
+    $this->attachment->formats()->create([
+        'format' => TestHero::class,
+        'data' => ['x' => 424242, 'y' => 56, 'width' => 100, 'height' => 100, 'rotate' => 0],
+    ]);
+
+    Livewire::test(FormatterModal::class, ['attachment' => $this->attachment])
+        ->call('setAttachment', $this->attachment->id, [TestHero::class])
+        ->assertStatus(200)
+        ->assertSee('424242', false);
+});
+
+it('rebuilds the cropper when switching formats instead of calling the no-op setData', function () {
+    Livewire::test(FormatterModal::class, ['attachment' => $this->attachment])
+        ->call('setAttachment', $this->attachment->id, [TestHero::class])
+        ->assertStatus(200)
+        // The fixed setFormat() rebuilds the cropper via loadFormatter()...
+        ->assertSee('this.loadFormatter()', false)
+        // ...and no longer applies the previous format's selection through the
+        // setData() call that is a no-op for formats without stored crop data.
+        ->assertDontSee('setData(this.previousFormats', false);
+});


### PR DESCRIPTION
When switching formats in the formatter modal, setFormat() applied the selected format's stored crop via cropper.setData(). For a format without a stored crop this resolved to setData({}), which is a no-op in Cropper.js, so the crop box, rotation and scale of the previously selected format stayed in place. The formatter therefore "remembered" the wrong crop.

Rebuild the cropper via the existing loadFormatter() on format switch so each format shows its own stored crop, or a clean default when it has none.

Refs AGR001-335