### PR TITLE
VIN005-76 Added options for formatter smoothing (3.x)

### DIFF
--- a/config/filament-media-library.php
+++ b/config/filament-media-library.php
@@ -5,6 +5,10 @@ use Codedor\MediaLibrary\Conversions\LocalConversion;
 return [
     'conversion' => LocalConversion::class,
     'enable-format-generate-action' => true,
+    'formatter-smoothing' => [
+        'enabled' => false,
+        'quality' => 'high',
+    ],
     'force-format-extension' => [
         'extension' => 'webp',
         'mime-type' => 'image/webp',

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,10 @@ return [
         'extension' => 'webp',
         'mime-type' => 'image/webp',
     ],
+    'formatter-smoothing' => [
+        'enabled' => false,
+        'quality' => 'high',
+    ],
     'format-queue' => 'default',
     'extensions' => [
         'image' => [
@@ -459,7 +463,7 @@ php artisan media:generate-format {--attachment-id=} {--format=} {--force}
 
 If you do not pass an `attachment-id`, the formats will be generated for all attachments.
 If you do not pass a `format`, all formats will be generated for the attachments.
-With `force` you can force the generation of the formats, even if they already exist. 
+With `force` you can force the generation of the formats, even if they already exist.
 
 > [!WARNING]
 > Using force will also overwrite cropped images!

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,25 @@ This configuration can be adjusted as desired.
 The format generation action is a button that will generate all the formats for the given attachment.
 This can be used on the Media Library as a bulk action. This action can be disabled by setting the `enable-format-generate-action` to false.
 
+### Formatter smoothing
+
+When cropping an image in the formatter, the resulting canvas can optionally use image smoothing. This is controlled
+through the `formatter-smoothing` key:
+
+```php
+'formatter-smoothing' => [
+    'enabled' => false,
+    'quality' => 'high',
+],
+```
+
+- `enabled`: whether image smoothing is applied when the cropped canvas is generated. This is `false` by default.
+- `quality`: the smoothing quality passed to the canvas. Accepts `'low'`, `'medium'` or `'high'`.
+
+These values map directly to the [`imageSmoothingEnabled`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled)
+and [`imageSmoothingQuality`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingQuality)
+canvas options used while cropping.
+
 ### S3 support
 
 To use S3 as a storage, you can use the `Codedor\MediaLibrary\Conversions\S3Conversion` class.

--- a/resources/views/livewire/formatter-modal.blade.php
+++ b/resources/views/livewire/formatter-modal.blade.php
@@ -52,7 +52,10 @@
                         format: this.currentFormat,
                         data: window.cropper.getData(),
                         crop: window.cropper
-                            .getCroppedCanvas()
+                            .getCroppedCanvas({
+                                imageSmoothingEnabled: {{ config('filament-media-library.formatter-smoothing.enabled', false) ? 'true' : 'false' }},
+                                imageSmoothingQuality: '{{ config('filament-media-library.formatter-smoothing.quality', 'high') }}',
+                            })
                             .toDataURL('image/png'),
                     })
                 },


### PR DESCRIPTION
Backport of #63 to the `3.x` branch.

Added config options to enable image smoothing on the formatter (off by default so we don't need a major tag).

The blade change is adapted to 3.x, where `getCroppedCanvas()` takes no width/height args and output stays `image/png`.